### PR TITLE
Base image on alpine, clean things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM fedora
-RUN yum -y install golang mongodb
-
+FROM alpine:3.2
 ADD mongoconf.go /
-RUN go build mongoconf.go
+RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk --update add go mongodb@testing \
+  && go build mongoconf.go \
+  && apk del go \
+  && rm -rf /var/cache/apk/*
 
 CMD /mongoconf $ARGS
-


### PR DESCRIPTION
Reduces the image size 10x from 330MB to 32MB.
`go build` still happens inside the image, we can use this approach for go apps?
